### PR TITLE
Payload support

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "body-parser": "^1.15.2",
     "chai": "^3.5.0",
     "feathers": "^2.0.2",
-    "feathers-authentication": "^1.0.0-beta",
+    "feathers-authentication": "^1.0.0-beta-1",
     "feathers-authentication-jwt": "^0.1.0",
     "feathers-hooks": "^1.6.1",
     "feathers-memory": "^0.8.1",

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,7 @@ const KEYS = [
   'entity',
   'service',
   'passReqToCallback',
-  'session',
-  'local'
+  'session'
 ];
 
 export default function init(options = {}) {
@@ -30,8 +29,12 @@ export default function init(options = {}) {
       throw new Error(`Can not find app.passport. Did you initialize feathers-authentication before feathers-authentication-local?`);
     }
 
+    let name = options.name || defaults.name;
+    let authOptions = app.get('auth') || {};
+    let localOptions = authOptions[name] || {};
+
     // NOTE (EK): Pull from global auth config to support legacy auth for an easier transition.
-    const localSettings = merge({}, defaults, pick(app.get('auth') || {}, KEYS), omit(options, ['Verifier']));
+    const localSettings = merge({}, defaults, pick(authOptions, KEYS), localOptions, omit(options, ['Verifier']));
     let Verifier = DefaultVerifier;
 
     if (options.Verifier) {
@@ -49,6 +52,7 @@ export default function init(options = {}) {
       // Register 'local' strategy with passport
       debug('Registering local authentication strategy with options:', localSettings);
       app.passport.use(localSettings.name, new LocalStrategy(localSettings, verifier.verify.bind(verifier)));
+      app.passport.options(localSettings.name, localSettings);
       
       return result;
     }

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -71,7 +71,11 @@ class LocalVerifier {
     this.service.find({ query })
       .then(this._normalizeResult)
       .then(entity => this._comparePassword(entity, password))
-      .then(entity => done(null, entity))
+      .then(entity => {
+        const id = entity[this.service.id];
+        const payload = { [`${this.options.entity}Id`]: id };
+        done(null, entity, payload);
+      })
       .catch(error => error ? done(error) : done(null, error));
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -55,6 +55,16 @@ describe('feathers-authentication-local', () => {
       passportLocal.Strategy.restore();
     });
 
+    it('registers the strategy options', () => {
+      sinon.spy(app.passport, 'options');
+      app.configure(local());
+      app.setup();
+
+      expect(app.passport.options).to.have.been.calledOnce;
+      
+      app.passport.options.restore();
+    });
+
     describe('passport strategy options', () => {
       let authOptions;
       let args;
@@ -106,6 +116,36 @@ describe('feathers-authentication-local', () => {
       app.setup();
 
       expect(passportLocal.Strategy.getCall(0).args[0].usernameField).to.equal('username');
+      
+      passportLocal.Strategy.restore();
+    });
+
+    it('pulls options from global config', () => {
+      sinon.spy(passportLocal, 'Strategy');
+      let authOptions = app.get('auth');
+      authOptions.local = { usernameField: 'username' };
+      app.set('auth', authOptions);
+
+      app.configure(local());
+      app.setup();
+
+      expect(passportLocal.Strategy.getCall(0).args[0].usernameField).to.equal('username');
+      expect(passportLocal.Strategy.getCall(0).args[0].passwordField).to.equal('password');
+      
+      passportLocal.Strategy.restore();
+    });
+
+    it('pulls options from global config with custom name', () => {
+      sinon.spy(passportLocal, 'Strategy');
+      let authOptions = app.get('auth');
+      authOptions.custom = { usernameField: 'username' };
+      app.set('auth', authOptions);
+
+      app.configure(local({ name: 'custom' }));
+      app.setup();
+
+      expect(passportLocal.Strategy.getCall(0).args[0].usernameField).to.equal('username');
+      expect(passportLocal.Strategy.getCall(0).args[0].passwordField).to.equal('password');
       
       passportLocal.Strategy.restore();
     });


### PR DESCRIPTION
### Summary

This PR:

- Fixes loading from global config #1 and #2 
- Now passes a payload with the entityId back to success.

Related to https://github.com/feathersjs/feathers-authentication/pull/349