### PR TITLE
Add support for dot notation, fix some whitespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,11 @@
     "bcryptjs": "^2.3.0",
     "debug": "^2.2.0",
     "feathers-errors": "^2.4.0",
+    "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.0",
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",
+    "lodash.set": "^4.3.2",
     "passport-local": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "lodash.merge": "^4.6.0",
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",
-    "lodash.set": "^4.3.2",
     "passport-local": "^1.0.0"
   },
   "devDependencies": {

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -1,7 +1,6 @@
 import Debug from 'debug';
 import errors from 'feathers-errors';
 import bcrypt from 'bcryptjs';
-import set from 'lodash.set';
 import get from 'lodash.get';
 
 const debug = Debug('feathers-authentication-local:verify');
@@ -66,11 +65,9 @@ class LocalVerifier {
   verify(req, username, password, done) {
     debug('Checking credentials', username, password);
     const query = {
+      [this.options.usernameField]: username,
       $limit: 1
     };
-
-    // set usernameField in query, accepting dot notation
-    set(query, this.options.usernameField, username);
 
     // Look up the entity
     this.service.find({ query })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -36,7 +36,7 @@ describe('feathers-authentication-local', () => {
       app.configure(authentication({ secret: 'supersecret' }));
     });
 
-    it('throws an error if passport has not been registered', () => {      
+    it('throws an error if passport has not been registered', () => {
       expect(() => {
         feathers().configure(local());
       }).to.throw();
@@ -50,7 +50,7 @@ describe('feathers-authentication-local', () => {
 
       expect(passportLocal.Strategy).to.have.been.calledOnce;
       expect(app.passport.use).to.have.been.calledWith('local');
-      
+
       app.passport.use.restore();
       passportLocal.Strategy.restore();
     });
@@ -61,7 +61,7 @@ describe('feathers-authentication-local', () => {
       app.setup();
 
       expect(app.passport.options).to.have.been.calledOnce;
-      
+
       app.passport.options.restore();
     });
 
@@ -116,7 +116,7 @@ describe('feathers-authentication-local', () => {
       app.setup();
 
       expect(passportLocal.Strategy.getCall(0).args[0].usernameField).to.equal('username');
-      
+
       passportLocal.Strategy.restore();
     });
 
@@ -131,7 +131,7 @@ describe('feathers-authentication-local', () => {
 
       expect(passportLocal.Strategy.getCall(0).args[0].usernameField).to.equal('username');
       expect(passportLocal.Strategy.getCall(0).args[0].passwordField).to.equal('password');
-      
+
       passportLocal.Strategy.restore();
     });
 
@@ -146,7 +146,7 @@ describe('feathers-authentication-local', () => {
 
       expect(passportLocal.Strategy.getCall(0).args[0].usernameField).to.equal('username');
       expect(passportLocal.Strategy.getCall(0).args[0].passwordField).to.equal('password');
-      
+
       passportLocal.Strategy.restore();
     });
 

--- a/test/verifier.test.js
+++ b/test/verifier.test.js
@@ -21,7 +21,7 @@ describe('Verifier', () => {
     return hasher('admin').then(password => {
       user = {
         email: 'admin@feathersjs.com',
-        password 
+        password
       };
 
       service = {
@@ -44,6 +44,8 @@ describe('Verifier', () => {
   it('exposes the Verifier class', () => {
     expect(typeof Verifier).to.equal('function');
   });
+
+
 
   describe('constructor', () => {
     it('retains an app reference', () => {
@@ -95,18 +97,33 @@ describe('Verifier', () => {
           expect(result).to.deep.equal(user);
         });
       });
+
+      it('allows dot notation for password field', () => {
+        const oldPasswordField = verifier.options.passwordField;
+
+        user.password = {
+          value: user.password
+        };
+
+        verifier.options.passwordField = 'password.value';
+
+        return verifier._comparePassword(user, 'admin').then(result => {
+          expect(result).to.deep.equal(user);
+          verifier.options.passwordField = oldPasswordField;
+        });
+      });
     });
   });
 
   describe('_normalizeResult', () => {
     describe('when has results', () => {
-      it('returns entity when paginated', () => {  
+      it('returns entity when paginated', () => {
         return verifier._normalizeResult({ data: [user] }).then(result => {
           expect(result).to.deep.equal(user);
         });
       });
 
-      it('returns entity when not paginated', () => {  
+      it('returns entity when not paginated', () => {
         return verifier._normalizeResult([user]).then(result => {
           expect(result).to.deep.equal(user);
         });
@@ -114,13 +131,13 @@ describe('Verifier', () => {
     });
 
     describe('when no results', () => {
-      it('rejects with false when paginated', () => {  
+      it('rejects with false when paginated', () => {
         return verifier._normalizeResult({ data: [] }).catch(error => {
           expect(error).to.equal(false);
         });
       });
 
-      it('rejects with false when not paginated', () => {  
+      it('rejects with false when not paginated', () => {
         return verifier._normalizeResult([]).catch(error => {
           expect(error).to.equal(false);
         });
@@ -179,6 +196,20 @@ describe('Verifier', () => {
       verifier.verify({}, user.email, 'admin', (error, entity) => {
         expect(error).to.equal(authError);
         expect(entity).to.equal(undefined);
+        done();
+      });
+    });
+
+    it('allows dot notation for username field', done => {
+      user.email = {
+        value: user.email
+      };
+
+      verifier.options.usernameField = 'email.value';
+
+      verifier.verify({}, user.email.value, 'admin', (error, entity) => {
+        expect(error).to.equal(null);
+        expect(entity).to.deep.equal(user);
         done();
       });
     });

--- a/test/verifier.test.js
+++ b/test/verifier.test.js
@@ -196,19 +196,5 @@ describe('Verifier', () => {
         done();
       });
     });
-
-    it('allows dot notation for username field', done => {
-      user.email = {
-        value: user.email
-      };
-
-      verifier.options.usernameField = 'email.value';
-
-      verifier.verify({}, user.email.value, 'admin', (error, entity) => {
-        expect(error).to.equal(null);
-        expect(entity).to.deep.equal(user);
-        done();
-      });
-    });
   });
 });

--- a/test/verifier.test.js
+++ b/test/verifier.test.js
@@ -99,8 +99,6 @@ describe('Verifier', () => {
       });
 
       it('allows dot notation for password field', () => {
-        const oldPasswordField = verifier.options.passwordField;
-
         user.password = {
           value: user.password
         };
@@ -109,7 +107,6 @@ describe('Verifier', () => {
 
         return verifier._comparePassword(user, 'admin').then(result => {
           expect(result).to.deep.equal(user);
-          verifier.options.passwordField = oldPasswordField;
         });
       });
     });


### PR DESCRIPTION
This PR adds support for dot notation in both the `usernameField` and `passwordField`.

Solves #7