### PR TITLE
use the correct default config key. Closes #21

### DIFF
--- a/src/hooks/hash-password.js
+++ b/src/hooks/hash-password.js
@@ -11,7 +11,7 @@ export default function hashPassword (options = {}) {
     }
 
     const app = hook.app;
-    const authOptions = app.get('auth') || {};
+    const authOptions = app.get('authentication') || {};
 
     options = merge({ passwordField: 'password' }, authOptions.local, options);
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export default function init(options = {}) {
     }
 
     let name = options.name || defaults.name;
-    let authOptions = app.get('auth') || {};
+    let authOptions = app.get('authentication') || {};
     let localOptions = authOptions[name] || {};
 
     // NOTE (EK): Pull from global auth config to support legacy auth for an easier transition.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -73,7 +73,7 @@ describe('feathers-authentication-local', () => {
         sinon.spy(passportLocal, 'Strategy');
         app.configure(local({ custom: true }));
         app.setup();
-        authOptions = app.get('auth');
+        authOptions = app.get('authentication');
         args = passportLocal.Strategy.getCall(0).args[0];
       });
 
@@ -122,9 +122,9 @@ describe('feathers-authentication-local', () => {
 
     it('pulls options from global config', () => {
       sinon.spy(passportLocal, 'Strategy');
-      let authOptions = app.get('auth');
+      let authOptions = app.get('authentication');
       authOptions.local = { usernameField: 'username' };
-      app.set('auth', authOptions);
+      app.set('authentication', authOptions);
 
       app.configure(local());
       app.setup();
@@ -137,9 +137,9 @@ describe('feathers-authentication-local', () => {
 
     it('pulls options from global config with custom name', () => {
       sinon.spy(passportLocal, 'Strategy');
-      let authOptions = app.get('auth');
+      let authOptions = app.get('authentication');
       authOptions.custom = { usernameField: 'username' };
-      app.set('auth', authOptions);
+      app.set('authentication', authOptions);
 
       app.configure(local({ name: 'custom' }));
       app.setup();

--- a/test/verifier.test.js
+++ b/test/verifier.test.js
@@ -31,7 +31,7 @@ describe('Verifier', () => {
       app.use('users', service)
         .configure(authentication({ secret: 'supersecret' }));
 
-      options = Object.assign({}, defaults, app.get('auth'));
+      options = Object.assign({}, defaults, app.get('authentication'));
 
       verifier = new Verifier(app, options);
     });


### PR DESCRIPTION
This is dependent on https://github.com/feathersjs/feathers-authentication/pull/506 and is a breaking change.