### PR TITLE
Entity fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ This will pull from your global `auth` object in your config file. It will also 
     name: 'local', // the name to use when invoking the authentication Strategy
     entity: 'user', // the entity that you're comparing username/password against
     service: 'users', // the service to look up the entity
-    usernameField: 'email', // key name of username field
-    passwordField: 'password', // key name of password field
+    usernameField: 'email', // key name of username field on the request
+    passwordField: 'password', // key name of password field on the request
+    entityUsernameField: 'email', // key name of the username field on the entity (defaults to `usernameField`)
+    entityPasswordField: 'password', // key name of the password on the entity (defaults to `passwordField`)
     passReqToCallback: true, // whether the request object should be passed to `verify`
     session: false // whether to use sessions,
     Verifier: Verifier // A Verifier class. Defaults to the built-in one but can be a custom one. See below for details.

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -21,11 +21,14 @@ class LocalVerifier {
   }
 
   _comparePassword(entity, password) {
+    // select entity password field - take entityPasswordField over passwordField
+    const passwordField = this.options.entityPasswordField || this.options.passwordField;
+
     // find password in entity, this allows for dot notation
-    const hash = get(entity, this.options.passwordField);
+    const hash = get(entity, passwordField);
 
     if (!hash) {
-      return Promise.reject(new Error(`'${this.options.entity}' record in the database is missing a '${this.options.passwordField}'`));
+      return Promise.reject(new Error(`'${this.options.entity}' record in the database is missing a '${passwordField}'`));
     }
 
     debug('Verifying password');

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -67,8 +67,12 @@ class LocalVerifier {
 
   verify(req, username, password, done) {
     debug('Checking credentials', username, password);
+
+    // Choose username field
+    const usernameField = this.options.entityUsernameField || this.options.usernameField;
+
     const query = {
-      [this.options.usernameField]: username,
+      [usernameField]: username,
       $limit: 1
     };
 

--- a/test/verifier.test.js
+++ b/test/verifier.test.js
@@ -109,6 +109,19 @@ describe('Verifier', () => {
           expect(result).to.deep.equal(user);
         });
       });
+
+      it('prefers entityPasswordField over passwordField', () => {
+        user.password = {
+          value: user.password
+        };
+
+        verifier.options.passwordField = 'password';
+        verifier.options.entityPasswordField = 'password.value';
+
+        return verifier._comparePassword(user, 'admin').then(result => {
+          expect(result).to.deep.equal(user);
+        });
+      })
     });
   });
 
@@ -150,6 +163,36 @@ describe('Verifier', () => {
         expect(service.find).to.have.been.calledWith({ query });
         done();
       });
+    });
+
+    it('allows overriding of usernameField', done => {
+      verifier.options.usernameField = 'username';
+
+      user.username = 'username';
+
+      verifier.verify({}, 'username', 'admin', (error, entity) => {
+        expect(error).to.equal(null);
+        expect(entity).to.deep.equal(user);
+        done();
+      })
+    });
+
+    it('prefers entityUsernameField over usernameField', done => {
+      verifier.options.usernameField = 'username';
+      verifier.options.entityUsernameField = 'users.username';
+
+      user.username = 'invalid';
+
+      user.users = {
+        username: 'valid'
+      };
+
+      verifier.verify({}, 'valid', 'admin', (error, entity) => {
+        expect(error).to.equal(null);
+        expect(entity).to.deep.equal(user);
+        done();
+      })
+
     });
 
     it('calls _normalizeResult', done => {


### PR DESCRIPTION
### Summary

This pull request adds the options `entityUsernameField` and `entityPasswordField`, corresponding to the fields on the user entity that contain the username and password fields respectively. If these options are not defined the username and password fields default back to `usernameField` and `passwordField`, maintaining backwards compatibility. This allows the separation of the {username,password}Fields on the user entity and on the incoming authentication request.

Concretely, this allows the following use case:

authentication-local options:
```
{
  entityUsernameField: 'services.email.address',
  entityPasswordField: 'services.email.password'
}
```
authentication request:

```
{
  strategy: 'local',
  username: 'test@email.com',
  password: 'test'
}
```

user entity:

```
{
  services: {
    email: {
      address: 'test@email.com'
      password: 'test'
    }
  }
}
```

### Open questions

* Are the field names correct? 
* Is it preferable to do it the other way round? `requestUsernameField` instead of `entityUsernameField`? Or all three?

